### PR TITLE
Disable serial console log to fix virtualbox error

### DIFF
--- a/release/Vagrantfile
+++ b/release/Vagrantfile
@@ -16,6 +16,7 @@ Vagrant.configure("2") do |config|
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
     vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+    vb.customize ["modifyvm", :id, "--uartmode1", "disconnected"]
   end
 
   # The VM for all stateful services (MongoDB, MySQL, Redis, etc.)


### PR DESCRIPTION
When trying to do ```vagrant up``` I got the error below. This change fixes it by disabling the serial log.

```
jdmulloy@xray:~/git/oc/edx-from-scratch/release$ vagrant up 
Bringing machine 'services' up with 'virtualbox' provider... 
Bringing machine 'platform' up with 'virtualbox' provider... 
==> services: Box 'smarnach/edx-services' could not be found. Attempting to find and install... 
   services: Box Provider: virtualbox 
   services: Box Version: >= 0 
==> services: Loading metadata for box 'smarnach/edx-services' 
   services: URL: https://vagrantcloud.com/smarnach/edx-services 
==> services: Adding box 'smarnach/edx-services' (v0.1.0) for provider: virtualbox 
   services: Downloading: https://vagrantcloud.com/smarnach/boxes/edx-services/versions/0.1.0/providers/virtualbox.box 
==> services: Successfully added box 'smarnach/edx-services' (v0.1.0) for 'virtualbox'! 
==> services: Importing base box 'smarnach/edx-services'... 
==> services: Matching MAC address for NAT networking... 
==> services: Setting the name of the VM: release_services_1527015911174_9765 
==> services: Fixed port collision for 22 => 2222. Now on port 2200. 
==> services: Clearing any previously set network interfaces... 
==> services: Preparing network interfaces based on configuration... 
   services: Adapter 1: nat 
   services: Adapter 2: hostonly 
==> services: Forwarding ports... 
   services: 22 (guest) => 2200 (host) (adapter 1) 
==> services: Running 'pre-boot' VM customizations... 
==> services: Booting VM... 
There was an error while executing `VBoxManage`, a CLI used by Vagrant 
for controlling VirtualBox. The command and stderr is shown below.                                                   
                                                                                                                    
Command: ["startvm", "f7290eba-95c6-4ce5-93e6-9ea429c797c2", "--type", "headless"]                                   
                                                                                                                    
Stderr: VBoxManage: error: RawFile#0 failed to create the raw output file /home/ubuntu/edx-from-scratch/ubuntu-xenia
l-16.04-cloudimg-console.log (VERR_FILE_NOT_FOUND)                                                                   
VBoxManage: error: Details: code NS_ERROR_FAILURE (0x80004005), component ConsoleWrap, interface IConsole
```